### PR TITLE
トップページに挨拶とログインユーザー名表示（API）

### DIFF
--- a/src/main/java/in/techcamp/app/controller/PrototypeController.java
+++ b/src/main/java/in/techcamp/app/controller/PrototypeController.java
@@ -38,9 +38,14 @@ public class PrototypeController {
   private final ImageUrl imageUrl;
 
   @GetMapping("/")
-  public String showPrototypes(Model model) {
+  public String showPrototypes(@AuthenticationPrincipal CustomUserDetail currentUser,
+                               Model model) {
     List<PrototypeEntity> prototypes = prototypeRepository.findAll();
     model.addAttribute("prototypes", prototypes);
+
+    if (currentUser != null) {
+      model.addAttribute("userName", currentUser.getLoginUserName());
+    }
     return "prototype/index";
   }
 

--- a/src/main/java/in/techcamp/app/custom_user/CustomUserDetail.java
+++ b/src/main/java/in/techcamp/app/custom_user/CustomUserDetail.java
@@ -27,6 +27,10 @@ public class CustomUserDetail implements UserDetails {
       return user.getId();
     }
 
+    public String getLoginUserName() {
+        return user.getUserName();
+    }
+
     @Override
     public String getUsername() {
         return user.getEmail();

--- a/src/test/java/in/techcamp/app/controller/PrototypeControllerUnitTest.java
+++ b/src/test/java/in/techcamp/app/controller/PrototypeControllerUnitTest.java
@@ -34,9 +34,11 @@ public class PrototypeControllerUnitTest {
 
   @Test
   public void 一覧表示機能にリクエストするとプロトタイプ一覧表示のビューファイルがレスポンスで返ってくる() {
+    UserEntity user = new UserEntity(); 
+    CustomUserDetail currentUser = new CustomUserDetail(user);
     Model model = new ExtendedModelMap();
 
-    String result = prototypeController.showPrototypes(model);
+    String result = prototypeController.showPrototypes(currentUser, model);
 
     assertThat(result, is("prototype/index"));
 
@@ -61,7 +63,7 @@ public class PrototypeControllerUnitTest {
     when(prototypeRepository.findAll()).thenReturn(expectedPrototypeList);
 
     Model model = new ExtendedModelMap();
-    prototypeController.showPrototypes(model);
+    prototypeController.showPrototypes(null, model);
 
     assertThat(model.getAttribute("prototypes"), is(expectedPrototypeList));
   }


### PR DESCRIPTION
# What
PrototypeController・CustomUserDetail・PrototypeControllerUnitTest修正
# Why
トップページに挨拶とログインユーザー名を表示するため。